### PR TITLE
Feature/fix donors

### DIFF
--- a/app/controllers/BiosampleController.scala
+++ b/app/controllers/BiosampleController.scala
@@ -82,7 +82,7 @@ class BiosampleController @Inject()(
    */
   def findByAliasOrAccession(query: String): Action[AnyContent] = Action.async {
     biosampleRepository.findByAliasOrAccession(query).map {
-      case Some(biosample) => Ok(Json.toJson(BiosampleView.fromDomain(biosample)))
+      case Some((biosample, specimenDonor)) => Ok(Json.toJson(BiosampleView.fromDomain(biosample, specimenDonor)))
       case None => NotFound(Json.obj("error" -> "Biosample not found"))
     }
   }

--- a/app/controllers/BiosampleMapController.scala
+++ b/app/controllers/BiosampleMapController.scala
@@ -20,7 +20,7 @@ class BiosampleMapController @Inject()(
   }
 
   def geoData() = Action.async { implicit request =>
-    biosampleRepository.getAllGeoLocations().map { locations =>
+    biosampleRepository.getAllGeoLocations.map { locations =>
       val geoJson = locations.map { case (point, count) =>
         Json.obj(
           "lat" -> point.getY,

--- a/app/controllers/SpecimenDonorController.scala
+++ b/app/controllers/SpecimenDonorController.scala
@@ -1,25 +1,29 @@
 package controllers
 
+import actions.ApiSecurityAction
 import jakarta.inject.{Inject, Singleton}
 import models.api.genomics.SpecimenDonorMergeRequest
+import play.api.libs.json.Json
 import play.api.mvc.*
 import services.genomics.SpecimenDonorService
-import play.api.libs.json.Json
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 @Singleton
 class SpecimenDonorController @Inject()(
                                          donorService: SpecimenDonorService,
+                                         secureApi: ApiSecurityAction,
                                          cc: ControllerComponents
                                        )(implicit ec: ExecutionContext) extends AbstractController(cc) {
 
   def mergeDonors(): Action[SpecimenDonorMergeRequest] = Action.async(parse.json[SpecimenDonorMergeRequest]) { request =>
-    donorService.mergeDonors(request.body).map { result =>
-      Ok(Json.toJson(result))
-    }.recover {
-      case e: IllegalArgumentException => BadRequest(Json.obj("error" -> e.getMessage))
-      case e: Exception => InternalServerError(Json.obj("error" -> "Failed to merge donors"))
-    }
+    secureApi.invokeBlock(request, { secureRequest =>
+      donorService.mergeDonors(request.body).map { result =>
+        Ok(Json.toJson(result))
+      }.recover {
+        case e: IllegalArgumentException => BadRequest(Json.obj("error" -> e.getMessage))
+        case e: Exception => InternalServerError(Json.obj("error" -> "Failed to merge donors"))
+      }
+    })
   }
 }

--- a/app/controllers/SpecimenDonorController.scala
+++ b/app/controllers/SpecimenDonorController.scala
@@ -9,6 +9,18 @@ import services.genomics.SpecimenDonorService
 
 import scala.concurrent.ExecutionContext
 
+/**
+ * Controller responsible for handling operations related to specimen donors.
+ *
+ * This controller provides endpoints for managing donor records, including
+ * the ability to merge multiple donors into a single unified record.
+ *
+ * @constructor Creates an instance of SpecimenDonorController
+ * @param donorService the service used to manage and merge specimen donor data
+ * @param secureApi    the security action used to secure API endpoints
+ * @param cc           controller components needed to construct the controller
+ * @param ec           the execution context for handling asynchronous operations
+ */
 @Singleton
 class SpecimenDonorController @Inject()(
                                          donorService: SpecimenDonorService,
@@ -16,6 +28,17 @@ class SpecimenDonorController @Inject()(
                                          cc: ControllerComponents
                                        )(implicit ec: ExecutionContext) extends AbstractController(cc) {
 
+  /**
+   * Merges multiple specimen donor records into a single unified record.
+   *
+   * This method handles the merging of donor data by using a secure API invocation.
+   * The merging process is performed based on the details provided in the request body,
+   * which includes the target donor ID, a list of source donor IDs, and the merge strategy.
+   * It returns the result of the operation or an appropriate error response in case of failure.
+   *
+   * @return An asynchronous `Action` that processes a `SpecimenDonorMergeRequest`
+   *         and yields a response containing the result of the donor merge operation.
+   */
   def mergeDonors(): Action[SpecimenDonorMergeRequest] = Action.async(parse.json[SpecimenDonorMergeRequest]) { request =>
     secureApi.invokeBlock(request, { secureRequest =>
       donorService.mergeDonors(request.body).map { result =>

--- a/app/controllers/SpecimenDonorController.scala
+++ b/app/controllers/SpecimenDonorController.scala
@@ -1,0 +1,25 @@
+package controllers
+
+import jakarta.inject.{Inject, Singleton}
+import models.api.genomics.SpecimenDonorMergeRequest
+import play.api.mvc.*
+import services.genomics.SpecimenDonorService
+import play.api.libs.json.Json
+
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class SpecimenDonorController @Inject()(
+                                         donorService: SpecimenDonorService,
+                                         cc: ControllerComponents
+                                       )(implicit ec: ExecutionContext) extends AbstractController(cc) {
+
+  def mergeDonors(): Action[SpecimenDonorMergeRequest] = Action.async(parse.json[SpecimenDonorMergeRequest]) { request =>
+    donorService.mergeDonors(request.body).map { result =>
+      Ok(Json.toJson(result))
+    }.recover {
+      case e: IllegalArgumentException => BadRequest(Json.obj("error" -> e.getMessage))
+      case e: Exception => InternalServerError(Json.obj("error" -> "Failed to merge donors"))
+    }
+  }
+}

--- a/app/models/api/BiosampleUpdate.scala
+++ b/app/models/api/BiosampleUpdate.scala
@@ -1,5 +1,6 @@
 package models.api
 
+import models.domain.genomics.BiologicalSex
 import play.api.libs.json.{Json, Reads}
 
 /**
@@ -15,7 +16,7 @@ import play.api.libs.json.{Json, Reads}
  * @param mtHaplogroup   An optional mitochondrial haplogroup assignment for the source of the biosample.
  */
 case class BiosampleUpdate(
-                            sex: Option[String] = None,
+                            sex: Option[BiologicalSex] = None,
                             geoCoord: Option[GeoCoord] = None,
                             alias: Option[String] = None,
                             locked: Option[Boolean] = None,

--- a/app/models/api/BiosampleView.scala
+++ b/app/models/api/BiosampleView.scala
@@ -1,6 +1,6 @@
 package models.api
 
-import models.domain.genomics.Biosample
+import models.domain.genomics.{Biosample, SpecimenDonor}
 import play.api.libs.json.{Json, OFormat}
 import utils.GeometryUtils
 
@@ -46,20 +46,21 @@ case class BiosampleView(
 object BiosampleView {
   implicit val format: OFormat[BiosampleView] = Json.format[BiosampleView]
 
-  def fromDomain(biosample: Biosample): BiosampleView = {
+  def fromDomain(biosample: Biosample, specimenDonor: Option[SpecimenDonor] = None): BiosampleView = {
     BiosampleView(
       id = biosample.id,
       sampleAccession = biosample.sampleAccession,
       description = biosample.description,
       alias = biosample.alias,
       centerName = biosample.centerName,
-      sex = biosample.sex,
-      geoCoord = biosample.geocoord.map(point => GeoCoord(point.getY, point.getX)),
+      sex = specimenDonor.flatMap(_.sex.map(_.toString)),
+      geoCoord = specimenDonor.flatMap(_.geocoord).map(point => GeoCoord(point.getY, point.getX)),
       specimenDonorId = biosample.specimenDonorId,
       sampleGuid = biosample.sampleGuid,
       locked = biosample.locked,
-      dateRangeStart = biosample.dateRangeStart,
-      dateRangeEnd = biosample.dateRangeEnd
+      dateRangeStart = specimenDonor.flatMap(_.dateRangeStart),
+      dateRangeEnd = specimenDonor.flatMap(_.dateRangeEnd)
     )
   }
 }
+

--- a/app/models/api/ExternalBiosampleRequest.scala
+++ b/app/models/api/ExternalBiosampleRequest.scala
@@ -1,5 +1,6 @@
 package models.api
 
+import models.domain.genomics.BiologicalSex
 import play.api.libs.json.{Json, OFormat}
 
 import java.time.LocalDateTime
@@ -20,12 +21,12 @@ import java.time.LocalDateTime
  * @param sequenceData    Information regarding the sequencing data associated with the biosample, represented by the `SequenceDataInfo` structure.
  */
 case class ExternalBiosampleRequest(
-                                     sampleAccession: String,  // Client provides their native identifier
-                                     sourceSystem: String,     // e.g., "evolbio", "pgp", etc.
+                                     sampleAccession: String, // Client provides their native identifier
+                                     sourceSystem: String, // e.g., "evolbio", "pgp", etc.
                                      description: String,
                                      alias: Option[String],
                                      centerName: String,
-                                     sex: Option[String],
+                                     sex: Option[BiologicalSex],
                                      latitude: Option[Double],
                                      longitude: Option[Double],
                                      publication: Option[PublicationInfo],

--- a/app/models/api/PgpBiosampleRequest.scala
+++ b/app/models/api/PgpBiosampleRequest.scala
@@ -1,5 +1,6 @@
 package models.api
 
+import models.domain.genomics.BiologicalSex
 import play.api.libs.json.{Json, OFormat}
 
 /**
@@ -16,7 +17,7 @@ case class PgpBiosampleRequest(
                                 participantId: String,
                                 description: String,
                                 centerName: String,
-                                sex: Option[String] = None,
+                                sex: Option[BiologicalSex] = None,
                                 latitude: Option[Double] = None,
                                 longitude: Option[Double] = None
                               )

--- a/app/models/api/genomics/SpecimanDonorMergeRequest.scala
+++ b/app/models/api/genomics/SpecimanDonorMergeRequest.scala
@@ -1,0 +1,52 @@
+package models.api.genomics
+
+import play.api.libs.json._
+
+enum MergeStrategy derives CanEqual {
+  case PreferTarget, PreferSource, MostComplete
+}
+
+object MergeStrategy {
+  implicit val format: Format[MergeStrategy] = new Format[MergeStrategy] {
+    def reads(json: JsValue): JsResult[MergeStrategy] = json.validate[String].map {
+      case "PreferTarget" => PreferTarget
+      case "PreferSource" => PreferSource
+      case "MostComplete" => MostComplete
+      case other => throw new IllegalArgumentException(s"Unknown merge strategy: $other")
+    }
+
+    def writes(strategy: MergeStrategy): JsValue = JsString(strategy.toString)
+  }
+}
+
+case class SpecimenDonorMergeRequest(
+                                      targetId: Int,
+                                      sourceIds: List[Int],
+                                      mergeStrategy: MergeStrategy
+                                    )
+
+object SpecimenDonorMergeRequest {
+  implicit val format: OFormat[SpecimenDonorMergeRequest] = Json.format[SpecimenDonorMergeRequest]
+}
+
+case class SpecimenDonorMergeResult(
+                                     mergedDonorId: Int,
+                                     updatedBiosamples: Int,
+                                     removedDonors: List[Int],
+                                     conflicts: List[MergeConflict]
+                                   )
+
+object SpecimenDonorMergeResult {
+  implicit val format: OFormat[SpecimenDonorMergeResult] = Json.format[SpecimenDonorMergeResult]
+}
+
+case class MergeConflict(
+                          field: String,
+                          targetValue: String,
+                          sourceValue: String,
+                          resolution: String
+                        )
+
+object MergeConflict {
+  implicit val format: OFormat[MergeConflict] = Json.format[MergeConflict]
+}

--- a/app/models/api/genomics/SpecimanDonorMergeRequest.scala
+++ b/app/models/api/genomics/SpecimanDonorMergeRequest.scala
@@ -2,10 +2,37 @@ package models.api.genomics
 
 import play.api.libs.json._
 
+/**
+ * Represents the strategy for resolving conflicts or handling decisions during a merge operation
+ * involving multiple specimen donors.
+ *
+ * The `MergeStrategy` enum provides the following options:
+ * - `PreferTarget`: Conflicts are resolved by preferring the data already present in the target donor.
+ * - `PreferSource`: Conflicts are resolved by preferring the data from the source donors over the target donor.
+ * - `MostComplete`: Conflicts are resolved by selecting the most complete data based on the aggregation of
+ * values from all donors involved in the merge.
+ */
 enum MergeStrategy derives CanEqual {
   case PreferTarget, PreferSource, MostComplete
 }
 
+/**
+ * Object providing JSON format support for the `MergeStrategy` enumeration.
+ *
+ * The implicit `Format` instance handles serialization and deserialization
+ * of `MergeStrategy` values to and from JSON. The JSON representation of a
+ * `MergeStrategy` is a string corresponding to the enumeration values:
+ * - `PreferTarget`
+ * - `PreferSource`
+ * - `MostComplete`
+ *
+ * Reads operations interpret the JSON string and convert it into the appropriate
+ * `MergeStrategy` value. If an unrecognized string is encountered, an
+ * `IllegalArgumentException` is thrown.
+ *
+ * Writes operations serialize a `MergeStrategy` value into its corresponding
+ * string representation for JSON output.
+ */
 object MergeStrategy {
   implicit val format: Format[MergeStrategy] = new Format[MergeStrategy] {
     def reads(json: JsValue): JsResult[MergeStrategy] = json.validate[String].map {
@@ -19,16 +46,46 @@ object MergeStrategy {
   }
 }
 
+/**
+ * Represents a request to merge specimen donors in a data management system.
+ *
+ * This case class encapsulates the details necessary to perform a donor merge operation,
+ * including the target donor ID, source donor IDs, and the strategy to handle conflicts or
+ * determine how data should be aggregated during the merge process.
+ *
+ * @param targetId      the unique identifier of the target donor into which the source donors will be merged
+ * @param sourceIds     a list of unique identifiers of the source donors to be merged into the target donor
+ * @param mergeStrategy specifies the strategy to use when resolving conflicts or combining data during the merge
+ */
 case class SpecimenDonorMergeRequest(
                                       targetId: Int,
                                       sourceIds: List[Int],
                                       mergeStrategy: MergeStrategy
                                     )
 
+/**
+ * Companion object for the `SpecimenDonorMergeRequest` case class.
+ *
+ * This object provides the implicit JSON format needed for serializing and
+ * deserializing instances of `SpecimenDonorMergeRequest`.
+ */
 object SpecimenDonorMergeRequest {
   implicit val format: OFormat[SpecimenDonorMergeRequest] = Json.format[SpecimenDonorMergeRequest]
 }
 
+/**
+ * Represents the result of a donor merge operation in a specimen management system.
+ *
+ * This case class captures the details of the outcome when multiple donor records are merged
+ * into a single record. It contains information about the resulting merged donor ID,
+ * the number of biosamples updated, the IDs of removed donors, and a list of any conflicts
+ * encountered during the merge operation.
+ *
+ * @param mergedDonorId     the unique identifier of the donor record that results from the merge operation
+ * @param updatedBiosamples the number of biosamples that were selected or reassigned to the merged donor
+ * @param removedDonors     a list of unique identifiers of source donors that were removed as part of the merge process
+ * @param conflicts         a list of conflicts encountered during the merge process, with details about the conflicting fields and resolutions
+ */
 case class SpecimenDonorMergeResult(
                                      mergedDonorId: Int,
                                      updatedBiosamples: Int,
@@ -36,10 +93,30 @@ case class SpecimenDonorMergeResult(
                                      conflicts: List[MergeConflict]
                                    )
 
+/**
+ * Companion object for the `SpecimenDonorMergeResult` case class.
+ *
+ * Provides JSON serialization and deserialization support for `SpecimenDonorMergeResult`.
+ * This is achieved using Play's JSON library to define the implicit `OFormat`.
+ *
+ * The `SpecimenDonorMergeResult` class represents the outcome of merging multiple donor
+ * records into a unified donor record. It includes details such as the merged donor ID,
+ * updated biosample count, removed donor IDs, and any merge conflicts encountered.
+ */
 object SpecimenDonorMergeResult {
   implicit val format: OFormat[SpecimenDonorMergeResult] = Json.format[SpecimenDonorMergeResult]
 }
 
+/**
+ * Represents a conflict encountered during a merge operation between a target donor
+ * and one or more source donors. A merge conflict occurs when the values of a specific
+ * field differ between the target and source donors.
+ *
+ * @param field       the name of the field where the conflict was detected
+ * @param targetValue the value of the field in the target donor
+ * @param sourceValue the value of the field in the source donor
+ * @param resolution  the resolved value for the conflicting field, derived from the merge strategy
+ */
 case class MergeConflict(
                           field: String,
                           targetValue: String,
@@ -47,6 +124,18 @@ case class MergeConflict(
                           resolution: String
                         )
 
+/**
+ * Companion object for the `MergeConflict` case class. This object provides
+ * implicit JSON serialization and deserialization functionality for `MergeConflict`
+ * instances.
+ *
+ * The `MergeConflict` case class represents a conflict that occurs during the
+ * process of merging donor data, with details about the conflicting field,
+ * the values in the target and source donors, and the resolved value.
+ *
+ * The implicit `OFormat` provided by this object is used to convert `MergeConflict`
+ * instances to and from JSON, facilitating their handling in APIs or persistent storage.
+ */
 object MergeConflict {
   implicit val format: OFormat[MergeConflict] = Json.format[MergeConflict]
 }

--- a/app/models/dal/MyPostgresProfile.scala
+++ b/app/models/dal/MyPostgresProfile.scala
@@ -1,7 +1,7 @@
 package models.dal
 
 import com.github.tminglei.slickpg.*
-import models.domain.genomics.BiosampleType
+import models.domain.genomics.{BiologicalSex, BiosampleType}
 import models.domain.publications.StudySource
 import play.api.libs.json.{JsValue, Json, OFormat, OWrites}
 import slick.basic.Capability
@@ -111,6 +111,12 @@ trait MyPostgresProfile extends ExPostgresProfile
       MappedJdbcType.base[BiosampleType, String](
         bt => bt.toString,  // converts BiosampleType to String for storage
         s => BiosampleType.valueOf(s)  // converts String back to BiosampleType
+      )
+
+    implicit val biologicalSexTypeMapper: JdbcType[BiologicalSex] =
+      MappedJdbcType.base[BiologicalSex, String](
+        bs => bs.toString,
+        s => BiologicalSex.valueOf(s)
       )
 
 

--- a/app/models/dal/domain/genomics/BiosamplesTable.scala
+++ b/app/models/dal/domain/genomics/BiosamplesTable.scala
@@ -1,53 +1,36 @@
 package models.dal.domain.genomics
 
-import com.vividsolutions.jts.geom.Point
 import models.dal.MyPostgresProfile.api.*
-import models.domain.genomics.{Biosample, BiosampleType}
+import models.domain.genomics.Biosample
 
 import java.util.UUID
 
 /**
  * Defines the Slick table mapping for the `Biosample` entity. This table represents 
- * biological samples with detailed metadata, including sample type, accession, 
- * description, and optional attributes such as donor information, geographical 
- * origin, and associated platforms.
+ * biological samples with their core identifiers and metadata.
  *
  * @param tag The Slick table tag used for binding the table to the database schema.
  */
 class BiosamplesTable(tag: Tag) extends Table[Biosample](tag, "biosample") {
   def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
-  def sampleType = column[BiosampleType]("sample_type")
   def sampleAccession = column[String]("sample_accession", O.Unique)
   def description = column[String]("description")
   def alias = column[Option[String]]("alias")
   def centerName = column[String]("center_name")
-  def sex = column[Option[String]]("sex")
-  def geocoord = column[Option[Point]]("geocoord")
   def specimenDonorId = column[Option[Int]]("specimen_donor_id")
   def sampleGuid = column[UUID]("sample_guid")
   def locked = column[Boolean]("locked", O.Default(false))
-  def pgpParticipantId = column[Option[String]]("pgp_participant_id")
-  def citizenBiosampleDid = column[Option[String]]("citizen_biosample_did")
   def sourcePlatform = column[Option[String]]("source_platform")
-  def dateRangeStart = column[Option[Int]]("date_range_start")
-  def dateRangeEnd = column[Option[Int]]("date_range_end")
 
   def * = (
     id.?,
-    sampleType,
     sampleGuid,
     sampleAccession,
     description,
     alias,
     centerName,
-    sex,
-    geocoord,
     specimenDonorId,
     locked,
-    pgpParticipantId,
-    citizenBiosampleDid,
-    sourcePlatform,
-    dateRangeStart,
-    dateRangeEnd
+    sourcePlatform
   ).mapTo[Biosample]
 }

--- a/app/models/dal/domain/genomics/SpecimenDonorsTable.scala
+++ b/app/models/dal/domain/genomics/SpecimenDonorsTable.scala
@@ -1,7 +1,8 @@
 package models.dal.domain.genomics
 
-import models.domain.genomics.SpecimenDonor
-import slick.jdbc.PostgresProfile.api.*
+import com.vividsolutions.jts.geom.Point
+import models.domain.genomics.{BiologicalSex, BiosampleType, SpecimenDonor}
+import models.dal.MyPostgresProfile.api.*
 
 /**
  * Represents the database table definition for storing specimen donor records.
@@ -25,10 +26,26 @@ import slick.jdbc.PostgresProfile.api.*
  */
 class SpecimenDonorsTable(tag: Tag) extends Table[SpecimenDonor](tag, "specimen_donor") {
   def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
-
   def donorIdentifier = column[String]("donor_identifier")
-
   def originBiobank = column[String]("origin_biobank")
+  def donorType = column[BiosampleType]("donor_type")
+  def sex = column[Option[BiologicalSex]]("sex")
+  def geocoord = column[Option[Point]]("geocoord")
+  def pgpParticipantId = column[Option[String]]("pgp_participant_id")
+  def citizenBiosampleDid = column[Option[String]]("citizen_biosample_did")
+  def dateRangeStart = column[Option[Int]]("date_range_start")
+  def dateRangeEnd = column[Option[Int]]("date_range_end")
 
-  def * = (id.?, donorIdentifier, originBiobank).mapTo[SpecimenDonor]
+  def * = (
+    id.?,
+    donorIdentifier,
+    originBiobank,
+    donorType,
+    sex,
+    geocoord,
+    pgpParticipantId,
+    citizenBiosampleDid,
+    dateRangeStart,
+    dateRangeEnd
+  ).mapTo[SpecimenDonor]
 }

--- a/app/models/domain/genomics/BiologicalSex.scala
+++ b/app/models/domain/genomics/BiologicalSex.scala
@@ -1,0 +1,58 @@
+package models.domain.genomics
+
+import play.api.libs.json.{Format, JsError, JsResult, JsString, JsSuccess, JsValue}
+
+/**
+ * Represents the biological sex of an individual or specimen. 
+ *
+ * The available enumeration values are:
+ * - `Male`: Represents male biological sex.
+ * - `Female`: Represents female biological sex.
+ * - `Unknown`: Represents an undefined or unstated biological sex.
+ * - `Intersex`: Represents intersex biological sex.
+ */
+enum BiologicalSex {
+  case Male, Female, Unknown, Intersex
+
+  def toLowerCase: String = this match {
+    case Male => "male"
+    case Female => "female"
+    case Unknown => "unknown"
+    case Intersex => "intersex" 
+  }
+}
+
+/**
+ * Provides functionality for interpreting and converting string values into 
+ * the corresponding `BiologicalSex` enumeration values. It also includes 
+ * implicit JSON formatting support for working with `BiologicalSex` in JSON 
+ * serialization and deserialization.
+ *
+ * This object supports mapping well-known string representations of 
+ * biological sexes (e.g., "male", "female", "intersex") to their respective 
+ * enumeration values, as well as defaulting to `Unknown` for unsupported or
+ * undefined values.
+ *
+ * - `fromString`: Converts a string value into a `BiologicalSex` instance 
+ * based on a case-insensitive match. Defaults to `Unknown` if no match is found.
+ * - `format`: An implicit `Format` instance for handling JSON reads and writes
+ * for `BiologicalSex` enumeration values. Assumes `String` values for both 
+ * serialization and deserialization.
+ */
+object BiologicalSex {
+  def fromString(s: String): BiologicalSex = Option(s).map(_.trim.toLowerCase) match {
+    case Some("male") => Male
+    case Some("female") => Female
+    case Some("intersex") => Intersex
+    case _ => Unknown
+  }
+
+  implicit val format: Format[BiologicalSex] = new Format[BiologicalSex] {
+    def reads(json: JsValue): JsResult[BiologicalSex] = json match {
+      case JsString(s) => JsSuccess(fromString(s))
+      case _ => JsError("String value expected")
+    }
+
+    def writes(sex: BiologicalSex): JsValue = JsString(sex.toLowerCase)
+  }
+}

--- a/app/models/domain/genomics/Biosample.scala
+++ b/app/models/domain/genomics/Biosample.scala
@@ -5,42 +5,26 @@ import com.vividsolutions.jts.geom.Point
 import java.util.UUID
 
 /**
- * Represents a biological sample, providing metadata such as its type, identifier, description, 
- * and several optional attributes describing its source, associated donor, 
- * and other related information.
+ * Represents a biosample with attributes describing its unique identifiers, source, and metadata.
  *
- * @param id                  An optional unique identifier for the biosample.
- * @param sampleType          The type of the biosample, represented as an enumeration value.
- * @param sampleGuid          A universally unique identifier (UUID) for the biosample.
- * @param sampleAccession     A unique accession string identifying the biosample.
- * @param description         A textual description of the biosample.
- * @param alias               An optional alias or alternate name for the biosample.
- * @param centerName          The name of the center responsible for the biosample.
- * @param sex                 An optional specification of the biological sex related to the biosample.
- * @param geocoord            An optional geographical coordinate indicating the origin of the biosample.
- * @param specimenDonorId     An optional unique identifier for the donor of the specimen.
- * @param locked              A boolean flag to indicate if the biosample is locked for editing or modifications.
- * @param pgpParticipantId    An optional identifier for a PGP participant associated with the biosample.
- * @param citizenBiosampleDid An optional decentralized identifier (DID) for the citizen's biosample.
- * @param sourcePlatform      An optional specification of the platform from which the biosample was sourced.
- * @param dateRangeStart      An optional starting year representing the range of dates linked to the biosample.
- * @param dateRangeEnd        An optional ending year representing the range of dates linked to the biosample.
+ * @param id              An optional unique identifier for the biosample, used for internal purposes.
+ * @param sampleGuid      A globally unique identifier for the biosample.
+ * @param sampleAccession A unique external accession for the biosample, often used for database references.
+ * @param description     A textual description of the biosample.
+ * @param alias           An optional short identifier or alias for the biosample, which may simplify referencing.
+ * @param centerName      The name of the organization or center responsible for the biosample.
+ * @param specimenDonorId An optional identifier linking the biosample to a specific specimen donor.
+ * @param locked          A flag indicating whether the biosample is immutable or restricted from further edits.
+ * @param sourcePlatform  An optional field specifying the platform or technology used to derive the biosample.
  */
 case class Biosample(
                       id: Option[Int] = None,
-                      sampleType: BiosampleType,
                       sampleGuid: UUID,
                       sampleAccession: String,
                       description: String,
                       alias: Option[String],
                       centerName: String,
-                      sex: Option[String],
-                      geocoord: Option[Point],
                       specimenDonorId: Option[Int],
                       locked: Boolean = false,
-                      pgpParticipantId: Option[String] = None,
-                      citizenBiosampleDid: Option[String] = None,
-                      sourcePlatform: Option[String] = None,
-                      dateRangeStart: Option[Int] = None,
-                      dateRangeEnd: Option[Int] = None
+                      sourcePlatform: Option[String] = None
                     )

--- a/app/models/domain/genomics/SpecimenDonor.scala
+++ b/app/models/domain/genomics/SpecimenDonor.scala
@@ -1,13 +1,32 @@
 package models.domain.genomics
 
+import com.vividsolutions.jts.geom.Point
+
 /**
- * Represents a specimen donor with metadata about their unique identifier, associated biobank, 
- * and other essential details. This class is typically used to link donors to biosamples and 
- * other related entities in a biobank or genomic research context. 
+ * Represents a donor of a specimen, encapsulating key attributes related to the donor, 
+ * their origin, biological characteristics, and other identifiers.
  *
- * @param id              An optional unique identifier for the specimen donor, used internally for tracking purposes.
- * @param donorIdentifier A required unique identifier for the donor, providing a way to reference the donor 
- *                        across different datasets or within a biobank.
- * @param originBiobank   The name or identifier of the biobank where the specimen donor originates.
+ * @param id                  An optional unique identifier for the specimen donor.
+ * @param donorIdentifier     A unique identifier for the donor, serving as an external reference.
+ * @param originBiobank       The name of the biobank or organization from which the donor originated.
+ * @param donorType           The type of biosample provided by the donor, expressed as a `BiosampleType`.
+ * @param sex                 An optional biological sex of the donor, represented as a `BiologicalSex` value.
+ * @param geocoord            An optional geographical coordinate indicating the origin location of the donor.
+ * @param pgpParticipantId    An optional identifier for the donor as a participant in the Personal Genome Project (PGP).
+ * @param citizenBiosampleDid An optional decentralized identifier (DID) for a citizen-defined biosample associated with the donor.
+ * @param dateRangeStart      An optional starting year for the time range relevant to the donor or specimen data.
+ * @param dateRangeEnd        An optional ending year for the time range relevant to the donor or specimen data.
  */
-case class SpecimenDonor(id: Option[Int] = None, donorIdentifier: String, originBiobank: String)
+case class SpecimenDonor(
+                          id: Option[Int] = None,
+                          donorIdentifier: String,
+                          originBiobank: String,
+                          donorType: BiosampleType,
+                          sex: Option[BiologicalSex],
+                          geocoord: Option[Point],
+                          pgpParticipantId: Option[String] = None,
+                          citizenBiosampleDid: Option[String] = None,
+                          dateRangeStart: Option[Int] = None,
+                          dateRangeEnd: Option[Int] = None
+                        )
+

--- a/app/modules/BaseModule.scala
+++ b/app/modules/BaseModule.scala
@@ -64,5 +64,9 @@ class BaseModule extends AbstractModule {
       .to(classOf[BiosampleAccessionGenerator])
       .asEagerSingleton()
 
+    bind(classOf[SpecimenDonorRepository])
+      .to(classOf[SpecimenDonorRepositoryImpl])
+      .asEagerSingleton()
+
   }
 }

--- a/app/modules/ServicesModule.scala
+++ b/app/modules/ServicesModule.scala
@@ -3,6 +3,7 @@ package modules
 import com.google.inject.AbstractModule
 import play.api.Mode.Prod
 import play.api.{Configuration, Environment, Mode}
+import services.genomics.{SpecimenDonorService, SpecimenDonorServiceImpl}
 import services.{AwsSesEmailService, EmailService, LoggingEmailService}
 
 class ServicesModule(environment: Environment, configuration: Configuration) extends AbstractModule {
@@ -13,5 +14,9 @@ class ServicesModule(environment: Environment, configuration: Configuration) ext
     }
 
     bind(classOf[EmailService]).to(emailService)
+
+    bind(classOf[SpecimenDonorService])
+      .to(classOf[SpecimenDonorServiceImpl])
+      .asEagerSingleton()
   }
 }

--- a/app/repositories/SpecimanDonorRepository.scala
+++ b/app/repositories/SpecimanDonorRepository.scala
@@ -1,0 +1,159 @@
+package repositories
+
+import jakarta.inject.{Inject, Singleton}
+import models.dal.DatabaseSchema
+import models.domain.genomics.{BiologicalSex, BiosampleType, SpecimenDonor}
+import play.api.db.slick.DatabaseConfigProvider
+import com.vividsolutions.jts.geom.Point
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait SpecimenDonorRepository {
+  def findById(id: Int): Future[Option[SpecimenDonor]]
+  def create(donor: SpecimenDonor): Future[SpecimenDonor]
+  def update(donor: SpecimenDonor): Future[Boolean]
+  def upsert(donor: SpecimenDonor): Future[SpecimenDonor]
+  def findByIdentifier(identifier: String): Future[Option[SpecimenDonor]]
+  def findByOriginBiobank(biobank: String): Future[Seq[SpecimenDonor]]
+  def findByType(donorType: BiosampleType): Future[Seq[SpecimenDonor]]
+  def findBySex(sex: BiologicalSex): Future[Seq[SpecimenDonor]]
+  def getAllGeoLocations: Future[Seq[(Point, Int)]]
+  def findByBiobankAndType(biobank: String, donorType: BiosampleType): Future[Seq[SpecimenDonor]]
+}
+
+@Singleton
+class SpecimenDonorRepositoryImpl @Inject()(
+                                             override protected val dbConfigProvider: DatabaseConfigProvider
+                                           )(implicit override protected val ec: ExecutionContext)
+  extends BaseRepository(dbConfigProvider)
+    with SpecimenDonorRepository {
+
+  import models.dal.MyPostgresProfile.api._
+
+  private val donorsTable = DatabaseSchema.domain.genomics.specimenDonors
+
+  override def findById(id: Int): Future[Option[SpecimenDonor]] = {
+    db.run(donorsTable.filter(_.id === id).result.headOption)
+  }
+
+  override def create(donor: SpecimenDonor): Future[SpecimenDonor] = {
+    val insertQuery = (donorsTable returning donorsTable.map(_.id)
+      into ((d, id) => d.copy(id = Some(id))))
+      .+=(donor)
+
+    db.run(insertQuery.transactionally)
+  }
+
+  override def update(donor: SpecimenDonor): Future[Boolean] = {
+    donor.id match {
+      case None => Future.successful(false)
+      case Some(id) =>
+        db.run(
+          donorsTable
+            .filter(_.id === id)
+            .map(d => (
+              d.donorIdentifier,
+              d.originBiobank,
+              d.donorType,
+              d.sex,
+              d.geocoord,
+              d.pgpParticipantId,
+              d.citizenBiosampleDid,
+              d.dateRangeStart,
+              d.dateRangeEnd
+            ))
+            .update((
+              donor.donorIdentifier,
+              donor.originBiobank,
+              donor.donorType,
+              donor.sex,
+              donor.geocoord,
+              donor.pgpParticipantId,
+              donor.citizenBiosampleDid,
+              donor.dateRangeStart,
+              donor.dateRangeEnd
+            ))
+            .map(_ > 0)
+        )
+    }
+  }
+
+  override def upsert(donor: SpecimenDonor): Future[SpecimenDonor] = {
+    val query = for {
+      existing <- donorsTable.filter(_.donorIdentifier === donor.donorIdentifier).result.headOption
+      result <- existing match {
+        case Some(existingDonor) =>
+          // Update existing donor
+          donorsTable
+            .filter(_.id === existingDonor.id)
+            .map(d => (
+              d.originBiobank,
+              d.donorType,
+              d.sex,
+              d.geocoord,
+              d.pgpParticipantId,
+              d.citizenBiosampleDid,
+              d.dateRangeStart,
+              d.dateRangeEnd
+            ))
+            .update((
+              donor.originBiobank,
+              donor.donorType,
+              donor.sex,
+              donor.geocoord,
+              donor.pgpParticipantId,
+              donor.citizenBiosampleDid,
+              donor.dateRangeStart,
+              donor.dateRangeEnd
+            ))
+            .map(_ => donor.copy(id = existingDonor.id))
+
+        case None =>
+          // Insert new donor
+          (donorsTable returning donorsTable.map(_.id)
+            into ((d, id) => d.copy(id = Some(id))))
+            .+=(donor)
+      }
+    } yield result
+
+    db.run(query.transactionally)
+  }
+
+  override def findByIdentifier(identifier: String): Future[Option[SpecimenDonor]] = {
+    db.run(donorsTable.filter(_.donorIdentifier === identifier).result.headOption)
+  }
+
+  override def findByOriginBiobank(biobank: String): Future[Seq[SpecimenDonor]] = {
+    db.run(donorsTable.filter(_.originBiobank === biobank).result)
+  }
+
+  override def findByType(donorType: BiosampleType): Future[Seq[SpecimenDonor]] = {
+    db.run(donorsTable.filter(_.donorType === donorType).result)
+  }
+
+  override def findBySex(sex: BiologicalSex): Future[Seq[SpecimenDonor]] = {
+    db.run(donorsTable.filter(_.sex === sex).result)
+  }
+
+  override def getAllGeoLocations: Future[Seq[(Point, Int)]] = {
+    val query = donorsTable
+      .filter(_.geocoord.isDefined)
+      .groupBy(_.geocoord)
+      .map { case (point, group) =>
+        (point.asColumnOf[Point], group.length)
+      }
+
+    db.run(query.result)
+  }
+
+  def findByBiobankAndType(
+                            biobank: String,
+                            donorType: BiosampleType
+                          ): Future[Seq[SpecimenDonor]] = {
+    db.run(
+      donorsTable
+        .filter(d => d.originBiobank === biobank && d.donorType === donorType)
+        .result
+    )
+  }
+}

--- a/app/services/BiosampleDataService.scala
+++ b/app/services/BiosampleDataService.scala
@@ -66,8 +66,8 @@ class BiosampleDataService @Inject()(
    */
   def linkPublication(sampleGuid: UUID, pubInfo: PublicationInfo): Future[Unit] = {
     for {
-      maybeBiosample <- biosampleRepository.findByGuid(sampleGuid)
-      biosample <- maybeBiosample match {
+      maybeBiosampleWithDonor <- biosampleRepository.findByGuid(sampleGuid)
+      (biosample, _) <- maybeBiosampleWithDonor match {
         case Some(b) => Future.successful(b)
         case None => Future.failed(new IllegalArgumentException(s"Biosample not found for GUID: $sampleGuid"))
       }
@@ -114,6 +114,7 @@ class BiosampleDataService @Inject()(
       }.getOrElse(Future.successful(()))
     } yield ()
   }
+
 
   private def createSequenceData(sampleGuid: UUID, data: SequenceDataInfo): Future[Unit] = {
     val library = SequenceLibrary(

--- a/app/services/BiosamplePublicationService.scala
+++ b/app/services/BiosamplePublicationService.scala
@@ -42,15 +42,16 @@ class BiosamplePublicationService @Inject()(
     }
 
     for {
-      biosample <- biosampleRepository.findByAccession(sampleAccession).flatMap {
-        case Some(sample) => Future.successful(sample)
+      biosampleWithDonor <- biosampleRepository.findByAccession(sampleAccession).flatMap {
+        case Some(result) => Future.successful(result)
         case None => Future.failed(new IllegalArgumentException(s"Biosample with accession $sampleAccession not found"))
       }
-
       publication <- publicationRepository.findByDoi(cleanDoi(doi)).flatMap {
         case Some(pub) => Future.successful(pub)
         case None => Future.failed(new IllegalArgumentException(s"Publication with DOI $doi not found"))
       }
+
+      (biosample, _) = biosampleWithDonor  // Destructure the tuple to get just the biosample
 
       link <- publicationBiosampleRepository.create(
         PublicationBiosample(
@@ -64,4 +65,5 @@ class BiosamplePublicationService @Inject()(
       )
     } yield link
   }
+
 }

--- a/app/services/BiosampleService.scala
+++ b/app/services/BiosampleService.scala
@@ -1,7 +1,7 @@
 package services
 
 import jakarta.inject.Inject
-import models.domain.genomics.Biosample
+import models.domain.genomics.{Biosample, SpecimenDonor}
 import repositories.BiosampleRepository
 
 import scala.concurrent.Future
@@ -26,5 +26,5 @@ class BiosampleService @Inject()(biosampleRepository: BiosampleRepository) {
    * @param id the unique identifier of the biosample to be retrieved
    * @return a Future containing an optional biosample instance; None is returned if no match is found
    */
-  def getBiosampleById(id: Int): Future[Option[Biosample]] = biosampleRepository.findById(id)
+  def getBiosampleById(id: Int): Future[Option[(Biosample, Option[SpecimenDonor])]] = biosampleRepository.findById(id)
 }

--- a/app/services/genomics/SpecimanDonorService.scala
+++ b/app/services/genomics/SpecimanDonorService.scala
@@ -1,22 +1,45 @@
 package services.genomics
 
+import jakarta.inject.{Inject, Singleton}
 import models.api.genomics.{MergeConflict, MergeStrategy, SpecimenDonorMergeRequest, SpecimenDonorMergeResult}
 import models.domain.genomics.SpecimenDonor
-import repositories.{BiosampleRepository, SpecimenDonorRepository}
-import jakarta.inject.{Inject, Singleton}
+import play.api.Logging
+import repositories.SpecimenDonorRepository
 
 import scala.concurrent.{ExecutionContext, Future}
 
+/**
+ * Service interface for managing and merging specimen donor data.
+ *
+ * This trait defines the contract for merging multiple donor records into a
+ * single unified donor record as per the provided merge request details.
+ */
 trait SpecimenDonorService {
+  /**
+   * Merges multiple donor records into a single unified donor record based on the specified merge strategy.
+   *
+   * @param request the merge request containing the target donor ID, a list of source donor IDs to be merged,
+   *                and the merge strategy to resolve conflicts or handle the merging process.
+   * @return a future containing the result of the merge operation, which includes the ID of the merged donor,
+   *         the count of updated biosamples, a list of removed donor IDs, and any merge conflicts encountered.
+   */
   def mergeDonors(request: SpecimenDonorMergeRequest): Future[SpecimenDonorMergeResult]
 }
 
 @Singleton
-class SpecimenDonorServiceImpl @Inject()(
-                                          donorRepo: SpecimenDonorRepository,
-                                          biosampleRepo: BiosampleRepository
-                                        )(implicit ec: ExecutionContext) extends SpecimenDonorService {
+class SpecimenDonorServiceImpl @Inject()(donorRepo: SpecimenDonorRepository)
+                                        (implicit ec: ExecutionContext) extends SpecimenDonorService with Logging {
 
+  /**
+   * Merges a target donor with multiple source donors based on the details specified in the request.
+   * The operation involves transferring biosamples from source donors to the target donor, deleting the source donors,
+   * and resolving potential conflicts according to a specified merge strategy.
+   *
+   * @param request the merge request containing the target donor ID, a list of source donor IDs to merge,
+   *                and the merge strategy to be applied
+   * @return a future containing the result of the merge operation, which includes the target donor ID,
+   *         count of updated biosamples, list of removed donor IDs, and any conflicts encountered during the merge
+   */
   def mergeDonors(request: SpecimenDonorMergeRequest): Future[SpecimenDonorMergeResult] = {
     for {
       // 1. Get all donors involved
@@ -33,6 +56,17 @@ class SpecimenDonorServiceImpl @Inject()(
     } yield result
   }
 
+  /**
+   * Processes the merging of a target donor with multiple source donors based on the provided merge request.
+   * This involves updating the target donor with merged data, transferring biosamples from the source donors
+   * to the target donor, deleting the source donors, and identifying any merge conflicts.
+   *
+   * @param targetDonor  the primary donor to which data and biosamples from the source donors will be merged
+   * @param sourceDonors a sequence of donors whose data and biosamples are to be merged into the target donor
+   * @param request      the merge request containing the target donor ID, a list of source donor IDs, and the strategy used for merging
+   * @return a future containing the result of the merge operation, which includes details about the merged donor ID,
+   *         number of updated biosamples, removed donor IDs, and any conflicts encountered during the merge
+   */
   private def processMerge(
                             targetDonor: SpecimenDonor,
                             sourceDonors: Seq[SpecimenDonor],
@@ -60,6 +94,15 @@ class SpecimenDonorServiceImpl @Inject()(
     )
   }
 
+  /**
+   * Merges donor data from a sequence of source donors into the target donor according to the specified merge strategy.
+   *
+   * @param target   the primary donor object to which data will be merged
+   * @param sources  a sequence of source donors whose data will be used in the merge process
+   * @param strategy the merge strategy determining how conflicts between target and source donors are resolved
+   *                 (PreferTarget, PreferSource, or MostComplete)
+   * @return a new SpecimenDonor instance representing the result of merging the target and source donors
+   */
   private def mergeDonorData(target: SpecimenDonor, sources: Seq[SpecimenDonor], strategy: MergeStrategy): SpecimenDonor = {
     strategy match {
       case MergeStrategy.PreferTarget => target
@@ -85,8 +128,70 @@ class SpecimenDonorServiceImpl @Inject()(
     }
   }
 
+  /**
+   * Identifies and collects merge conflicts between a target donor and multiple source donors
+   * in the context of a merge operation. A conflict arises when the values of corresponding
+   * fields in the target and source donors differ.
+   *
+   * @param target  the primary donor whose values are compared against the source donors
+   * @param sources a list of source donors whose values are compared against the target donor
+   * @param result  the merged donor, used to determine the resolved value for conflicting fields
+   * @return a list of `MergeConflict` instances representing the fields where conflicts were detected,
+   *         including details of the conflicting values and the chosen resolution
+   */
   private def collectMergeConflicts(target: SpecimenDonor, sources: List[SpecimenDonor], result: SpecimenDonor): List[MergeConflict] = {
-    // Implementation for tracking merge conflicts
-    Nil // TODO: Implement conflict collection
+    logger.info(s"Starting merge conflict detection for target donor ${target.id} with ${sources.length} source donors")
+
+    // Helper function to compare values and create conflict if they differ
+    def checkField[T](fieldName: String, targetValue: Option[T], sourceValue: Option[T], resultValue: Option[T]): Option[MergeConflict] = {
+      (targetValue, sourceValue) match {
+        case (Some(tv), Some(sv)) if tv != sv =>
+          val conflict = MergeConflict(
+            field = fieldName,
+            targetValue = tv.toString,
+            sourceValue = sv.toString,
+            resolution = resultValue.map(_.toString).getOrElse("No value")
+          )
+          logger.debug(s"Found conflict in field '$fieldName': target='$tv', source='$sv', resolved to='${resultValue.getOrElse("No value")}'")
+          Some(conflict)
+        case _ => None
+      }
+    }
+
+    // For multiple sources, we'll compare against the first different value we find
+    val conflictingSources = sources.filter(_ != target)
+    if (conflictingSources.isEmpty) {
+      logger.info("No conflicting sources found - all sources match target")
+      return Nil
+    }
+
+    logger.debug(s"Found ${conflictingSources.length} conflicting source donors")
+
+    val conflicts = conflictingSources.flatMap { source =>
+      logger.debug(s"Checking conflicts between target donor ${target.id} and source donor ${source.id}")
+
+      val fieldConflicts = List(
+        checkField("donorType", Option(target.donorType), Option(source.donorType), Option(result.donorType)),
+        checkField("sex", target.sex, source.sex, result.sex),
+        checkField("geocoord", target.geocoord, source.geocoord, result.geocoord),
+        checkField("pgpParticipantId", target.pgpParticipantId, source.pgpParticipantId, result.pgpParticipantId),
+        checkField("citizenBiosampleDid", target.citizenBiosampleDid, source.citizenBiosampleDid, result.citizenBiosampleDid),
+        checkField("dateRangeStart", target.dateRangeStart, source.dateRangeStart, result.dateRangeStart),
+        checkField("dateRangeEnd", target.dateRangeEnd, source.dateRangeEnd, result.dateRangeEnd)
+      ).flatten
+
+      if (fieldConflicts.isEmpty) {
+        logger.debug(s"No field conflicts found between target donor ${target.id} and source donor ${source.id}")
+      }
+
+      fieldConflicts
+    }.distinct
+
+    logger.info(s"Completed merge conflict detection: found ${conflicts.length} unique conflicts")
+    if (conflicts.nonEmpty) {
+      logger.debug(s"Conflict summary: ${conflicts.map(c => s"${c.field}: ${c.targetValue} vs ${c.sourceValue}").mkString(", ")}")
+    }
+
+    conflicts
   }
 }

--- a/app/services/genomics/SpecimanDonorService.scala
+++ b/app/services/genomics/SpecimanDonorService.scala
@@ -1,0 +1,92 @@
+package services.genomics
+
+import models.api.genomics.{MergeConflict, MergeStrategy, SpecimenDonorMergeRequest, SpecimenDonorMergeResult}
+import models.domain.genomics.SpecimenDonor
+import repositories.{BiosampleRepository, SpecimenDonorRepository}
+import jakarta.inject.{Inject, Singleton}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait SpecimenDonorService {
+  def mergeDonors(request: SpecimenDonorMergeRequest): Future[SpecimenDonorMergeResult]
+}
+
+@Singleton
+class SpecimenDonorServiceImpl @Inject()(
+                                          donorRepo: SpecimenDonorRepository,
+                                          biosampleRepo: BiosampleRepository
+                                        )(implicit ec: ExecutionContext) extends SpecimenDonorService {
+
+  def mergeDonors(request: SpecimenDonorMergeRequest): Future[SpecimenDonorMergeResult] = {
+    for {
+      // 1. Get all donors involved
+      targetDonorOpt <- donorRepo.findById(request.targetId)
+      sourceDonors <- Future.sequence(request.sourceIds.map(donorRepo.findById))
+
+      // 2. Validate all donors exist
+      result <- (targetDonorOpt, sourceDonors.flatten) match {
+        case (Some(targetDonor), sources) if sources.length == request.sourceIds.length =>
+          processMerge(targetDonor, sources, request)
+        case _ =>
+          Future.failed(new IllegalArgumentException("One or more donors not found"))
+      }
+    } yield result
+  }
+
+  private def processMerge(
+                            targetDonor: SpecimenDonor,
+                            sourceDonors: Seq[SpecimenDonor],
+                            request: SpecimenDonorMergeRequest
+                          ): Future[SpecimenDonorMergeResult] = {
+
+    // Merge donor data according to strategy
+    val mergedDonor = mergeDonorData(targetDonor, sourceDonors, request.mergeStrategy)
+
+    for {
+      // Update target donor with merged data
+      _ <- donorRepo.update(mergedDonor)
+
+      // Transfer all biosamples to target donor
+      updatedCount <- donorRepo.transferBiosamples(request.sourceIds, request.targetId)
+
+      // Delete source donors
+      _ <- donorRepo.deleteMany(request.sourceIds)
+
+    } yield SpecimenDonorMergeResult(
+      mergedDonorId = request.targetId,
+      updatedBiosamples = updatedCount,
+      removedDonors = request.sourceIds,
+      conflicts = collectMergeConflicts(targetDonor, sourceDonors.toList, mergedDonor)
+    )
+  }
+
+  private def mergeDonorData(target: SpecimenDonor, sources: Seq[SpecimenDonor], strategy: MergeStrategy): SpecimenDonor = {
+    strategy match {
+      case MergeStrategy.PreferTarget => target
+      case MergeStrategy.PreferSource => sources.head.copy(id = target.id)
+      case MergeStrategy.MostComplete =>
+        sources.foldLeft(target) { (acc, source) =>
+          SpecimenDonor(
+            id = acc.id,
+            donorIdentifier = acc.donorIdentifier,
+            originBiobank = acc.originBiobank,
+            donorType = (source.donorType, acc.donorType) match {
+              case (null, accType) => accType
+              case (sourceType, _) => sourceType
+            },
+            sex = source.sex.orElse(acc.sex),
+            geocoord = source.geocoord.orElse(acc.geocoord),
+            pgpParticipantId = source.pgpParticipantId.orElse(acc.pgpParticipantId),
+            citizenBiosampleDid = source.citizenBiosampleDid.orElse(acc.citizenBiosampleDid),
+            dateRangeStart = source.dateRangeStart.orElse(acc.dateRangeStart),
+            dateRangeEnd = source.dateRangeEnd.orElse(acc.dateRangeEnd)
+          )
+        }
+    }
+  }
+
+  private def collectMergeConflicts(target: SpecimenDonor, sources: List[SpecimenDonor], result: SpecimenDonor): List[MergeConflict] = {
+    // Implementation for tracking merge conflicts
+    Nil // TODO: Implement conflict collection
+  }
+}

--- a/conf/evolutions/default/18.sql
+++ b/conf/evolutions/default/18.sql
@@ -1,0 +1,104 @@
+-- !Ups
+
+-- Create enum types
+CREATE TYPE biological_sex AS ENUM ('male', 'female', 'intersex');
+CREATE TYPE biosample_type AS ENUM ('Standard', 'PGP', 'Citizen', 'Ancient');
+
+-- Add new columns to specimen_donor with temporary nullability
+ALTER TABLE specimen_donor
+    ADD COLUMN sex biological_sex,
+    ADD COLUMN geocoord geometry(Point, 4326),
+    ADD COLUMN date_range_start integer,
+    ADD COLUMN date_range_end integer,
+    ADD COLUMN donor_type biosample_type,
+    ADD COLUMN pgp_participant_id varchar(50),
+    ADD COLUMN citizen_biosample_did varchar(255);
+
+-- Migrate data from biosample to specimen_donor
+UPDATE specimen_donor sd
+SET sex = CASE
+              WHEN b.sex = 'male' THEN 'male'::biological_sex
+              WHEN b.sex = 'female' THEN 'female'::biological_sex
+              WHEN b.sex = 'intersex' THEN 'intersex'::biological_sex
+              ELSE NULL
+    END,
+    geocoord = b.geocoord,
+    date_range_start = b.date_range_start,
+    date_range_end = b.date_range_end,
+    donor_type = b.sample_type::biosample_type,
+    pgp_participant_id = b.pgp_participant_id,
+    citizen_biosample_did = b.citizen_biosample_did
+FROM biosample b
+WHERE b.specimen_donor_id = sd.id;
+
+-- Set default value and not null constraint for donor_type after data migration
+ALTER TABLE specimen_donor
+    ALTER COLUMN donor_type SET NOT NULL,
+    ALTER COLUMN donor_type SET DEFAULT 'Standard',
+    ADD CONSTRAINT pgp_participant_id_required
+        CHECK (donor_type != 'PGP' OR (donor_type = 'PGP' AND pgp_participant_id IS NOT NULL)),
+    ADD CONSTRAINT citizen_did_required
+        CHECK (donor_type != 'Citizen' OR (donor_type = 'Citizen' AND citizen_biosample_did IS NOT NULL));
+
+-- Remove migrated columns from biosample
+ALTER TABLE biosample
+    DROP COLUMN sex,
+    DROP COLUMN geocoord,
+    DROP COLUMN sample_type,
+    DROP COLUMN pgp_participant_id,
+    DROP COLUMN citizen_biosample_did,
+    DROP COLUMN date_range_start,
+    DROP COLUMN date_range_end,
+    DROP CONSTRAINT IF EXISTS pgp_participant_id_required,
+    DROP CONSTRAINT IF EXISTS citizen_did_required,
+    DROP CONSTRAINT IF EXISTS biosample_sex_check,
+    DROP CONSTRAINT IF EXISTS biosample_type_check;
+
+-- !Downs
+
+-- Add columns back to biosample
+ALTER TABLE biosample
+    ADD COLUMN sex varchar(15),
+    ADD COLUMN geocoord geometry(Point, 4326),
+    ADD COLUMN sample_type varchar(10),
+    ADD COLUMN pgp_participant_id varchar(50),
+    ADD COLUMN citizen_biosample_did varchar(255),
+    ADD COLUMN date_range_start integer,
+    ADD COLUMN date_range_end integer;
+
+-- Migrate data back from specimen_donor to biosample
+UPDATE biosample b
+SET sex = sd.sex::text,
+    geocoord = sd.geocoord,
+    sample_type = sd.donor_type::text,
+    pgp_participant_id = sd.pgp_participant_id,
+    citizen_biosample_did = sd.citizen_biosample_did,
+    date_range_start = sd.date_range_start,
+    date_range_end = sd.date_range_end
+FROM specimen_donor sd
+WHERE b.specimen_donor_id = sd.id;
+
+-- Add constraints back to biosample
+ALTER TABLE biosample
+    ADD CONSTRAINT biosample_sex_check
+        CHECK (sex IN ('male', 'female', 'intersex')),
+    ADD CONSTRAINT biosample_type_check
+        CHECK (sample_type IN ('Standard', 'PGP', 'Citizen', 'Ancient')),
+    ADD CONSTRAINT pgp_participant_id_required
+        CHECK (sample_type != 'PGP' OR (sample_type = 'PGP' AND pgp_participant_id IS NOT NULL)),
+    ADD CONSTRAINT citizen_did_required
+        CHECK (sample_type != 'Citizen' OR (sample_type = 'Citizen' AND citizen_biosample_did IS NOT NULL));
+
+-- Remove added columns from specimen_donor
+ALTER TABLE specimen_donor
+    DROP COLUMN sex,
+    DROP COLUMN geocoord,
+    DROP COLUMN date_range_start,
+    DROP COLUMN date_range_end,
+    DROP COLUMN donor_type,
+    DROP COLUMN pgp_participant_id,
+    DROP COLUMN citizen_biosample_did;
+
+-- Drop the enum types (need to drop them last since columns depend on them)
+DROP TYPE biological_sex;
+DROP TYPE biosample_type;

--- a/conf/routes
+++ b/conf/routes
@@ -70,6 +70,9 @@ POST          /api/private/external/biosamples                                  
 POST          /api/private/external/biosamples/:sampleGuid/sequences                             controllers.BiosampleDataController.addSequenceData(sampleGuid: java.util.UUID)
 POST          /api/private/external/biosamples/:sampleGuid/publication                           controllers.BiosampleDataController.linkPublication(sampleGuid: java.util.UUID)
 
+# Specimen Donor endpoints
+POST          /api/private/donors/merge                                                          controllers.SpecimenDonorController.mergeDonors()
+
 # --- API Routes (Handled by Tapir, including Swagger UI) ---
 # Delegate all requests starting with /api to the Tapir-based ApiRouter
 ->            /api                                                                               controllers.ApiRouter


### PR DESCRIPTION
Moving the meta-data that is more an element of the specimen source out of the biosample table to specimen_donor.  Duplication is proving to be a larger issue than originally anticipated in the schema design.

Adding a protected API that can merge specimen_donors since there will surely be many to clean-up after this is released and they will continue to accumulate as new studies are batch imported.